### PR TITLE
Allowing latest react native versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pusher-push-notifications",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Manage pusher channel subscriptions from within React Native JS",
   "main": "index.js",
   "scripts": {
@@ -19,7 +19,7 @@
   "author": "b8ne",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.60.0"
+    "react-native": ">=0.60.0"
   },
   "bugs": {
     "url": "https://github.com/b8ne/react-native-pusher-push-notifications/issues"


### PR DESCRIPTION
Allowed react native versions >= 0.60 (peer dependency)